### PR TITLE
Check types are identical for probably_missing_eq

### DIFF
--- a/pytest_clarity/util.py
+++ b/pytest_clarity/util.py
@@ -22,7 +22,7 @@ def display_op_for(pytest_op):
 def possibly_missing_eq(lhs, rhs):
     try:
         left_dict, right_dict = vars(lhs), vars(rhs)
-        return isinstance(lhs, type(rhs)) and lhs != rhs and left_dict == right_dict
+        return (type(lhs) is type(rhs)) and lhs != rhs and left_dict == right_dict
     except TypeError:
         return False
 

--- a/testing/test_util.py
+++ b/testing/test_util.py
@@ -2,7 +2,12 @@
 
 import pytest
 
-from pytest_clarity.util import display_op_for, has_differing_len, pformat_no_color
+from pytest_clarity.util import (
+    display_op_for,
+    has_differing_len,
+    pformat_no_color,
+    possibly_missing_eq,
+)
 
 
 class SingleArg(object):
@@ -46,3 +51,13 @@ def test_has_differing_len(lhs, rhs, is_diff_len):
 @pytest.mark.parametrize("arg, result", [("s", '"s"'), ([1], "[1]"), (["1"], "['1']")])
 def test_pformat_no_color(arg, result):
     assert pformat_no_color(arg, 60) == result
+
+
+def test_possibly_missing_eq_false_with_subclass():
+    class Thing:
+        a = 1
+
+    class SubThing(Thing):
+        pass
+
+    assert not possibly_missing_eq(Thing(), SubThing())

--- a/testing/test_util.py
+++ b/testing/test_util.py
@@ -54,7 +54,7 @@ def test_pformat_no_color(arg, result):
 
 
 def test_possibly_missing_eq_false_with_subclass():
-    class Thing:
+    class Thing(object):
         a = 1
 
     class SubThing(Thing):


### PR DESCRIPTION
Currently, `probably_missing_eq` compares types using `isinstance` rather than identity.  This means that 
 1. `assert item_of_subclass == item_of_class` produces a message stating that the items are equal in type;
 2. `assert item_of_class == item_of_subcless` does *not* produce a similar message; and 
 3.  the output also states that values are identical, even if the class and subclass have different class-level attribute values.

Using identity comparison solves all of that.