### PR TITLE
Add support for Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 # Config file for automatic testing at travis-ci.org
 
-sudo: false
 language: python
 
 matrix:
@@ -16,7 +15,6 @@ matrix:
   - python: 3.7
     env: TOX_ENV=py37
     dist: xenial
-    sudo: true
 
 install:
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ matrix:
     env: TOX_ENV=py35
   - python: 3.6
     env: TOX_ENV=py36
+  - python: 3.7
+    env: TOX_ENV=py37
+    dist: xenial
+    sudo: true
 
 install:
   - pip install -r requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: Implementation :: CPython",
         "Operating System :: OS Independent",
         "License :: OSI Approved :: MIT License",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py27,py34,py35,py36,flake8
+envlist = py27, py34, py35, py36, py37, flake8
 
 [testenv]
 deps = -rrequirements.txt


### PR DESCRIPTION
Add support for Python 3.7, which needs Xenial and sudo on Travis CI (https://github.com/travis-ci/travis-ci/issues/9815).