### PR TITLE
Import Sequence from collections.abc

### DIFF
--- a/pytest_clarity/hints.py
+++ b/pytest_clarity/hints.py
@@ -1,4 +1,4 @@
-from collections import Sequence
+from collections.abc import Sequence
 
 from pytest_clarity.output import deleted_text, hint_body_text, hint_text, inserted_text
 from pytest_clarity.util import (


### PR DESCRIPTION
Fixes deprecation warnings on Python 3.8+ and restores compatibility with Python 3.10.

Fixes #11