### PR TITLE
Add flag for disabling output, regardless verbosity

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,3 +60,8 @@ You can configure the width of the output with the :code:`--diff-width` option:
 You can force `pytest-clarity` to show a symbolic diff with :code:`--diff-symbols`::
 
     pytest -vv --diff-symbols
+
+
+In case you want to explicitly disable `pytest-clarity` but keep the verbosity level, you can force that with :code:`--disable-clarity`::
+
+    pytest -vv --disable-clarity

--- a/pytest_clarity/plugin.py
+++ b/pytest_clarity/plugin.py
@@ -19,10 +19,16 @@ def pytest_addoption(parser):
         default=False,
         help="pytest-clarity: configure whether to display diff symbols",
     )
+    parser.addoption(
+        "--disable-clarity",
+        action="store_true",
+        default=False,
+        help="pytest-clarity: disable regardless verbosity option",
+    )
 
 
 def pytest_assertrepr_compare(config, op, left, right):
-    if config.getoption("-v") < 2:
+    if config.getoption("--disable-clarity") or config.getoption("-v") < 2:
         return
 
     op = display_op_for(op)


### PR DESCRIPTION
Hello and thanks for the plugin!

Because the plugin depends on the verbosity flags, there may be scenarios in which it can be useful or convenient to decouple it and explicitly disable `pytest-clarity`, e.g. when you don't have control over the runner that doesn't have support for ANSI escape sequences.

I hope it makes sense!